### PR TITLE
Use connection string directly rather than parsing

### DIFF
--- a/src/database/connection.js
+++ b/src/database/connection.js
@@ -10,7 +10,6 @@ if (!DB_URL) throw new Error("Enviroment variable DB_URL must be set");
 
 const options = {
   connectionString: DB_URL,
-  max: 2,
   ssl: !DB_URL.includes("localhost"),
 };
 

--- a/src/database/connection.js
+++ b/src/database/connection.js
@@ -1,4 +1,3 @@
-const { parse } = require("url");
 const { Pool } = require("pg");
 require("dotenv").config();
 
@@ -9,17 +8,10 @@ const DB_URL =
 
 if (!DB_URL) throw new Error("Enviroment variable DB_URL must be set");
 
-const { auth, hostname: host, port, pathname } = parse(process.env.DB_URL);
-const [user, password] = auth.split(":");
-
 const options = {
-  host,
-  port,
-  database: pathname.split("/")[1],
+  connectionString: DB_URL,
   max: 2,
-  user,
-  password,
-  ssl: host !== "localhost",
+  ssl: !DB_URL.includes("localhost"),
 };
 
 module.exports = new Pool(options);


### PR DESCRIPTION
node-postgres can parse the url itself, so we don't have to faff around splitting it etc